### PR TITLE
Fix grep command in Fastfile and bump to v1.0.6

### DIFF
--- a/Claw.xcconfig
+++ b/Claw.xcconfig
@@ -2,7 +2,7 @@
 // This file contains the app version and distribution channel
 // Automatically updated during release process
 
-APP_VERSION = 1.0.0
+APP_VERSION = 1.0.6
 APP_DISTRIBUTION_CHANNEL = stable
 
 // Marketing version visible to users

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -232,7 +232,7 @@ platform :mac do
     xcconfig_path = File.absolute_path("../Claw.xcconfig")
     sh("sed -i '' 's/APP_DISTRIBUTION_CHANNEL = .*/APP_DISTRIBUTION_CHANNEL = stable/' #{xcconfig_path}")
 
-    original_version = sh("cat #{xcconfig_path} | grep APP_VERSION =").split("APP_VERSION = ").last.strip
+    original_version = sh("grep 'APP_VERSION =' #{xcconfig_path}").split("APP_VERSION = ").last.strip
     version = find_available_version(original_version)
 
     # Update version if changed


### PR DESCRIPTION
## Summary

- Fixes shell command error in `distribute_release` lane (Fastfile:235)
- Bumps `APP_VERSION` from 1.0.0 to 1.0.6 to test first automated release

## Problem

The `distribute_release` lane was failing with:
```
grep: =: No such file or directory
```

**Root cause:** The grep pattern wasn't properly quoted in the shell command:
```ruby
sh("cat #{xcconfig_path} | grep APP_VERSION =")
```

The shell interpreted `=` as a separate filename argument instead of part of the search pattern.

## Solution

Changed to properly quoted direct grep:
```ruby
sh("grep 'APP_VERSION =' #{xcconfig_path}")
```

Benefits:
- ✅ Proper quoting prevents shell misinterpretation
- ✅ More efficient (no unnecessary `cat` pipe)
- ✅ Cleaner code

## Testing

After merge, this will enable testing the first automated release with:
```bash
cd fastlane && bundle exec fastlane distribute_release
```

Expected behavior:
1. Read version 1.0.6 from Claw.xcconfig
2. Build, sign, and notarize app
3. Create GitHub Release with ZIP + DMG
4. Update appcast.xml and create PR

## Checklist

- [x] Fix tested locally (error resolved)
- [x] Version bumped to 1.0.6
- [x] No secrets exposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)