### PR TITLE
Release v1.0.6

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -6,19 +6,19 @@
     <description>Claw app updates</description>
     <language>en</language>
     <item>
-      <title>Version 1.0.0</title>
+      <title>Version 1.0.6</title>
       <link>https://github.com/jamesrochabrun/Claw</link>
+      <sparkle:version>1.0.6</sparkle:version>
       <sparkle:channel>stable</sparkle:channel>
       <description><![CDATA[
-        Initial release of Claw with automatic updates support.
+        Release version 1.0.6
       ]]></description>
-      <pubDate>Fri, 18 Oct 2025 23:13:00 +0000</pubDate>
+      <pubDate>Sat, 18 Oct 2025 23:03:05 -0700</pubDate>
       <enclosure
-        url="https://github.com/jamesrochabrun/Claw/releases/download/v1.0.0/Claw.app.zip"
-        sparkle:version="1"
-        sparkle:shortVersionString="1.0.0"
-        sparkle:edSignature="pJUw+c04LIs60Q8wPo2btmRYrfrwie0DZGapzbAPfBLhUv+v7oPoLORVbPTtNSevjDBgYqZmbUy0JaiHXQUJCA=="
-        length="8781099"
+        url="https://github.com/jamesrochabrun/Claw/releases/download/v1.0.6/Claw.app.zip"
+        sparkle:version="1.0.6"
+        sparkle:edSignature="2dGf2FycgV7R8Wt5e9s5ghjXoltoHh0yXUY5/ixhxJtp9CW+fwJ3l7Ew+XWMYAXcQIfkupxADvGFFnNzYNGtCg=="
+        length="8781280"
         type="application/octet-stream" />
     </item>
   </channel>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -198,6 +198,10 @@ platform :mac do
 
     sparkle_output = sh("echo '#{sparkle_secret_key}' | #{sparkle_path}/bin/sign_update #{app_zip_path} --ed-key-file -")
 
+    # Parse signature from output: sparkle:edSignature="SIGNATURE" length="SIZE"
+    signature_match = sparkle_output.match(/sparkle:edSignature="([^"]+)"/)
+    ed_signature = signature_match ? signature_match[1] : ""
+
     # Get version from xcconfig
     xcconfig_path = File.absolute_path("../Claw.xcconfig")
     version ||= sh("cat #{xcconfig_path} | grep APP_VERSION=").split("APP_VERSION = ").last.strip
@@ -216,7 +220,7 @@ platform :mac do
     appcast_content.gsub!("REPLACE_VERSION", version)
     appcast_content.gsub!("REPLACE_DESCRIPTION", "Release version #{version}")
     appcast_content.gsub!("REPLACE_PUBDATE", current_date)
-    appcast_content.gsub!("REPLACE_SIGNATURE", sparkle_output.strip)
+    appcast_content.gsub!("REPLACE_SIGNATURE", ed_signature)
     appcast_content.gsub!("REPLACE_LENGTH", zip_size.to_s)
 
     File.write(appcast_path, appcast_content)


### PR DESCRIPTION
## Summary

Release version 1.0.6 with automatic updates support.

## Changes

### appcast.xml
- Updated to version 1.0.6
- Added EdDSA signature: `2dGf2FycgV7R8Wt5e9s5ghjXoltoHh0yXUY5/ixhxJtp9CW+fwJ3l7Ew+XWMYAXcQIfkupxADvGFFnNzYNGtCg==`
- Updated file size: 8,781,280 bytes
- Download URL: https://github.com/jamesrochabrun/Claw/releases/download/v1.0.6/Claw.app.zip

### Fastfile
- Fixed Sparkle signature parsing to extract only the signature value
- Added regex parsing: `sparkle:edSignature="([^"]+)"`
- Prevents malformed XML in future releases

## Release Assets

✅ **GitHub Release created:** https://github.com/jamesrochabrun/Claw/releases/tag/v1.0.6

**Assets uploaded:**
- `Claw.app.zip` (8.4 MB) - For automatic Sparkle updates
- `Claw.dmg` (Notarized) - For manual downloads

## Verification

- ✅ App built and signed with Developer ID
- ✅ All binaries signed (including ApprovalMCPServer)
- ✅ Notarized by Apple
- ✅ DMG created and signed
- ✅ Sparkle ZIP signed with EdDSA key
- ✅ appcast.xml signature verified

## User Impact

After merging this PR:
- Existing users will receive automatic update notification
- New users can download from GitHub Releases
- All updates cryptographically verified with EdDSA signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)