### PR TITLE
Fix DMG creation to include /Applications symlink

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -180,10 +180,26 @@ platform :mac do
     UI.message("Stapling notarization ticket...")
     sh("xcrun stapler staple '#{app_path}'")
 
-    # Create DMG
+    # Create DMG with /Applications symlink for drag-and-drop installation
     dmg_path = "#{build_path}/release/#{app_name}.dmg"
     sh("rm -f '#{dmg_path}'") if File.exist?(dmg_path)
-    sh("create-dmg --volname '#{app_name}' --codesign '#{certificate_name}' '#{dmg_path}' '#{app_path}'")
+
+    # Create temporary folder structure for DMG
+    temp_dmg_dir = "#{build_path}/dmg_temp"
+    sh("rm -rf '#{temp_dmg_dir}'")
+    sh("mkdir -p '#{temp_dmg_dir}'")
+
+    # Copy app to temp directory
+    sh("cp -R '#{app_path}' '#{temp_dmg_dir}/'")
+
+    # Create Applications symlink for drag-and-drop installation
+    sh("ln -s /Applications '#{temp_dmg_dir}/Applications'")
+
+    # Create and sign DMG from temp directory
+    sh("create-dmg --volname '#{app_name}' --codesign '#{certificate_name}' '#{dmg_path}' '#{temp_dmg_dir}'")
+
+    # Clean up temp directory
+    sh("rm -rf '#{temp_dmg_dir}'")
 
     # Verify signatures
     puts "Verifying code signature..."


### PR DESCRIPTION
Previously, create-dmg was called with the app bundle directly, which prevented the /Applications symlink from being created. Users had no visual guide for drag-and-drop installation.

This change creates a temporary folder structure containing:
- The Claw.app bundle
- A symlink to /Applications

This provides the standard Mac installer experience where users can drag the app icon to the Applications folder icon.

Changes:
- Create temp directory structure before DMG creation
- Copy app into temp directory
- Create /Applications symlink in temp directory
- Pass temp directory to create-dmg (not the app directly)
- Clean up temp directory after DMG creation

This matches the approach already proven in create_dmg.sh script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)