### PR TITLE
Remove unnecessary dangerous entitlements

### DIFF
--- a/Claw/Claw.entitlements
+++ b/Claw/Claw.entitlements
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-	<true/>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>


### PR DESCRIPTION
## Summary
Removes two dangerous security entitlements that were added in commit ad1cbab but are not actually needed for the app's functionality.

## Changes
- ❌ Removed `com.apple.security.cs.allow-unsigned-executable-memory`
- ❌ Removed `com.apple.security.cs.disable-library-validation`
- ✅ Kept `com.apple.security.network.client` (needed for Anthropic API)
- ✅ Kept `com.apple.security.network.server` (needed for MCP approval server)

## Why These Entitlements Are Not Needed
The app uses `HeadlessBackend` which spawns `/bin/zsh` to execute the `claude` CLI as a separate process. It also bundles a pure Swift MCP approval server. Neither of these require:
- JIT (Just-In-Time) compilation (`allow-unsigned-executable-memory`)
- Loading unsigned libraries (`disable-library-validation`)

These entitlements were likely added from a generic template without understanding their specific purpose. Removing them improves app security without affecting functionality.

## Testing
After removal, the app should continue to work normally:
- ✅ Claude Code execution via CLI
- ✅ Xcode integration/detection (uses Accessibility APIs)
- ✅ MCP approval server
- ✅ Network calls to Anthropic API